### PR TITLE
Additional functionality

### DIFF
--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -42,4 +42,5 @@ cloudprovider:
     additional_ports: [] # list of tuples of additional ports to map/forward
     admin_username: "" # username to log in to the AzureML Training Cluster for 'local' runs
     admin_ssh_key: "" # password to log in to the AzureML Training Cluster for 'local' runs
+    telemetry_opt_out: False # by default we log the version of the AzureMLCluster being used, set to True to opt-out 
     datastores: [] # default list of datastores to mount

--- a/dask_cloudprovider/cloudprovider.yaml
+++ b/dask_cloudprovider/cloudprovider.yaml
@@ -37,7 +37,7 @@ cloudprovider:
     jupyter_port: 9000 # default Jupyter lab port on the headnode
     dashboard_port: 9001 # default Dask dashboard port on the headnode
     scheduler_port: 9002 # default for the scheduler port if using from outside of cluster VNET
-    scheduler_idle_timeout: 300 # default timeout for dask-scheduler process to shutdown if idle (in seconds)
+    scheduler_idle_timeout: 1200 # default timeout for dask-scheduler process to shutdown if idle (in seconds)
     worker_death_timeout: 30 # default timeout for dask-worker process upon losing scheduler
     additional_ports: [] # list of tuples of additional ports to map/forward
     admin_username: "" # username to log in to the AzureML Training Cluster for 'local' runs

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -24,9 +24,11 @@ from distributed.utils import (
 logger = logging.getLogger(__name__)
 done = False  # FLAG FOR STOPPING THE port_forward_logger THREAD
 
-
-from azureml._base_sdk_common.user_agent import append
-append('AzureMLCluster-DASK', '0.1')
+try:
+    from azureml._base_sdk_common.user_agent import append  
+    append('AzureMLCluster-DASK', '0.1')
+except:
+    pass
 
 
 def port_forward_logger(portforward_proc):
@@ -744,6 +746,8 @@ class AzureMLCluster(Cluster):
 
     # close cluster
     async def _close(self):
+        await super()._close()
+
         if self.status == "closed":
             return
         while self.workers_list:
@@ -755,7 +759,6 @@ class AzureMLCluster(Cluster):
             self.run.complete()
             self.run.cancel()
 
-        await super()._close()
         self.status = "closed"
         self.__print_message("Scheduler and workers are disconnected.")
 

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -450,7 +450,7 @@ class AzureMLCluster(Cluster):
             scheduler_public_port = self.compute_target.list_nodes()[0]["port"]
 
             cmd = (
-                "ssh -vvv -o StrictHostKeyChecking=no -N"
+                "ssh -vvv -N"
                 f" -i {self.admin_ssh_key}"
                 f" -L 0.0.0.0:{self.jupyter_port}:{scheduler_ip}:8888"
                 f" -L 0.0.0.0:{self.dashboard_port}:{scheduler_ip}:8787"

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -470,6 +470,8 @@ class AzureMLCluster(Cluster):
                 stderr=subprocess.STDOUT,
             )
 
+            print(cmd)
+
             print('Waiting for ssh tunnel...')
             time.sleep(30)   #### WAIT FOR THE CONNECTION TO ESTABLISH
 

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -451,7 +451,7 @@ class AzureMLCluster(Cluster):
 
             cmd = (
                 "ssh -vvv -o StrictHostKeyChecking=no "
-                f" -i os.path.expanduser({self.admin_ssh_key})"
+                f" -i {os.path.expanduser(self.admin_ssh_key)}"
                 f" -L 0.0.0.0:{self.jupyter_port}:{scheduler_ip}:8888"
                 f" -L 0.0.0.0:{self.dashboard_port}:{scheduler_ip}:8787"
                 f" -L 0.0.0.0:{self.scheduler_port}:{scheduler_ip}:8786"

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -450,8 +450,8 @@ class AzureMLCluster(Cluster):
             scheduler_public_port = self.compute_target.list_nodes()[0]["port"]
 
             cmd = (
-                "ssh -vvv -N -o StrictHostKeyChecking=no "
-                f" -i {self.admin_ssh_key}"
+                "ssh -vvv -o StrictHostKeyChecking=no "
+                f" -i os.path.expanduser({self.admin_ssh_key})"
                 f" -L 0.0.0.0:{self.jupyter_port}:{scheduler_ip}:8888"
                 f" -L 0.0.0.0:{self.dashboard_port}:{scheduler_ip}:8787"
                 f" -L 0.0.0.0:{self.scheduler_port}:{scheduler_ip}:8786"

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -450,7 +450,7 @@ class AzureMLCluster(Cluster):
             scheduler_public_port = self.compute_target.list_nodes()[0]["port"]
 
             cmd = (
-                "ssh -vvv -o StrictHostKeyChecking=no "
+                "ssh -vvv -N -o StrictHostKeyChecking=no "
                 f" -i {os.path.expanduser(self.admin_ssh_key)}"
                 f" -L 0.0.0.0:{self.jupyter_port}:{scheduler_ip}:8888"
                 f" -L 0.0.0.0:{self.dashboard_port}:{scheduler_ip}:8787"

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -470,6 +470,10 @@ class AzureMLCluster(Cluster):
                 stderr=subprocess.STDOUT,
             )
 
+            print('Waiting for ssh tunnel...')
+            time.sleep(30)   #### WAIT FOR THE CONNECTION TO ESTABLISH
+
+
     @property
     def dashboard_link(self):
         """ Link to Dask dashboard.

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -450,7 +450,7 @@ class AzureMLCluster(Cluster):
             scheduler_public_port = self.compute_target.list_nodes()[0]["port"]
 
             cmd = (
-                "ssh -vvv -N"
+                "ssh -vvv -N -o StrictHostKeyChecking=no "
                 f" -i {self.admin_ssh_key}"
                 f" -L 0.0.0.0:{self.jupyter_port}:{scheduler_ip}:8888"
                 f" -L 0.0.0.0:{self.dashboard_port}:{scheduler_ip}:8787"

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -462,6 +462,9 @@ class AzureMLCluster(Cluster):
 
             cmd += f" {self.admin_username}@{scheduler_public_ip} -p {scheduler_public_port}"
 
+            print(cmd)
+
+
             portforward_log = open("portforward_out_log.txt", "w")
             portforward_proc = subprocess.Popen(
                 cmd.split(),
@@ -470,7 +473,6 @@ class AzureMLCluster(Cluster):
                 stderr=subprocess.STDOUT,
             )
 
-            print(cmd)
 
             print('Waiting for ssh tunnel...')
             time.sleep(90)   #### WAIT FOR THE CONNECTION TO ESTABLISH

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -25,6 +25,10 @@ logger = logging.getLogger(__name__)
 done = False  # FLAG FOR STOPPING THE port_forward_logger THREAD
 
 
+from azureml._base_sdk_common.user_agent import append
+append('AzureMLCluster-DASK', '0.1')
+
+
 def port_forward_logger(portforward_proc):
     portforward_log = open("portforward_out_log.txt", "w")
 
@@ -173,6 +177,7 @@ class AzureMLCluster(Cluster):
         self.dashboard_port = dashboard_port
         self.scheduler_port = scheduler_port
         self.scheduler_idle_timeout = scheduler_idle_timeout
+        self.portforward_proc = None
         self.worker_death_timeout = worker_death_timeout
 
         if additional_ports is not None:
@@ -754,9 +759,10 @@ class AzureMLCluster(Cluster):
         self.status = "closed"
         self.__print_message("Scheduler and workers are disconnected.")
 
-        ### STOP LOGGING SSH
-        self.portforward_proc.terminate()
-        done = True
+        if self.portforward_proc is not None:
+            ### STOP LOGGING SSH
+            self.portforward_proc.terminate()
+            done = True
 
     def close(self):
         """ Close the cluster. All Azure ML Runs corresponding to the scheduler

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -746,8 +746,6 @@ class AzureMLCluster(Cluster):
 
     # close cluster
     async def _close(self):
-        await super()._close()
-
         if self.status == "closed":
             return
         while self.workers_list:
@@ -766,6 +764,9 @@ class AzureMLCluster(Cluster):
             ### STOP LOGGING SSH
             self.portforward_proc.terminate()
             done = True
+
+        time.sleep(30)
+        await super()._close()
 
     def close(self):
         """ Close the cluster. All Azure ML Runs corresponding to the scheduler

--- a/dask_cloudprovider/providers/azure/azureml.py
+++ b/dask_cloudprovider/providers/azure/azureml.py
@@ -473,7 +473,8 @@ class AzureMLCluster(Cluster):
             print(cmd)
 
             print('Waiting for ssh tunnel...')
-            time.sleep(30)   #### WAIT FOR THE CONNECTION TO ESTABLISH
+            time.sleep(90)   #### WAIT FOR THE CONNECTION TO ESTABLISH
+            print('Trying to connect')
 
 
     @property

--- a/dask_cloudprovider/providers/azure/setup/start_scheduler.py
+++ b/dask_cloudprovider/providers/azure/setup/start_scheduler.py
@@ -8,10 +8,7 @@ import argparse
 import threading
 import subprocess
 import logging
-
-import json
 import os
-from pathlib import Path
 
 from mpi4py import MPI
 from azureml.core import Run
@@ -43,7 +40,7 @@ if __name__ == "__main__":
     parser.add_argument("--jupyter_port", default=8888)
     parser.add_argument("--dashboard_port", default=8787)
     parser.add_argument("--scheduler_port", default=8786)
-    parser.add_argument("--scheduler_idle_timeout", default=300)  # 5 mins
+    parser.add_argument("--scheduler_idle_timeout", default=1200)  # 20 mins
     parser.add_argument("--worker_death_timeout", default=30)  # 30 seconds
     parser.add_argument("--use_gpu", default=False)
     parser.add_argument("--n_gpus_per_node", default=0)

--- a/dask_cloudprovider/providers/azure/setup/start_scheduler.py
+++ b/dask_cloudprovider/providers/azure/setup/start_scheduler.py
@@ -9,6 +9,20 @@ import threading
 import subprocess
 import logging
 
+import json
+import os
+from pathlib import Path
+
+AZUREML_DIR = Path('~').expanduser() / '.azureml'
+AZUREML_DIR.mkdir(exist_ok=True)
+CLIENTINFO = AZUREML_DIR / 'clientinfo.json'
+
+NAME = 'AzureMLCluster-DASK'
+VERSION = '0.1'
+
+with CLIENTINFO.open(mode='w') as f:
+    json.dump(dict(name=NAME, version=VERSION), f)
+
 from mpi4py import MPI
 from azureml.core import Run
 from notebook.notebookapp import list_running_servers

--- a/dask_cloudprovider/providers/azure/setup/start_scheduler.py
+++ b/dask_cloudprovider/providers/azure/setup/start_scheduler.py
@@ -13,9 +13,6 @@ import json
 import os
 from pathlib import Path
 
-from azureml._base_sdk_common.user_agent import append
-append('AzureMLCluster-DASK', '0.1')
-
 from mpi4py import MPI
 from azureml.core import Run
 from notebook.notebookapp import list_running_servers

--- a/dask_cloudprovider/providers/azure/setup/start_scheduler.py
+++ b/dask_cloudprovider/providers/azure/setup/start_scheduler.py
@@ -8,7 +8,6 @@ import argparse
 import threading
 import subprocess
 import logging
-import os
 
 from mpi4py import MPI
 from azureml.core import Run
@@ -41,7 +40,7 @@ if __name__ == "__main__":
     parser.add_argument("--dashboard_port", default=8787)
     parser.add_argument("--scheduler_port", default=8786)
     parser.add_argument("--scheduler_idle_timeout", default=1200)  # 20 mins
-    parser.add_argument("--worker_death_timeout", default=30)  # 30 seconds
+    parser.add_argument("--worker_death_timeout", default=300)  # 5 mins
     parser.add_argument("--use_gpu", default=False)
     parser.add_argument("--n_gpus_per_node", default=0)
 

--- a/dask_cloudprovider/providers/azure/setup/start_scheduler.py
+++ b/dask_cloudprovider/providers/azure/setup/start_scheduler.py
@@ -13,15 +13,8 @@ import json
 import os
 from pathlib import Path
 
-AZUREML_DIR = Path('~').expanduser() / '.azureml'
-AZUREML_DIR.mkdir(exist_ok=True)
-CLIENTINFO = AZUREML_DIR / 'clientinfo.json'
-
-NAME = 'AzureMLCluster-DASK'
-VERSION = '0.1'
-
-with CLIENTINFO.open(mode='w') as f:
-    json.dump(dict(name=NAME, version=VERSION), f)
+from azureml._base_sdk_common.user_agent import append
+append('AzureMLCluster-DASK', '0.1')
 
 from mpi4py import MPI
 from azureml.core import Run

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -257,7 +257,7 @@ To create cluster:
 
       ### UNCOMMENT BELOW FOR LOCAL RUNS
       # admin_username=admin_username,
-      # admin_ssh_key=admin_ssh_key_priv,
+      # admin_ssh_key=admin_ssh_key_priv   ### path, not contents of the key
    )
 
 Once the cluster has started, the Dask Cluster widget will print out two links:


### PR DESCRIPTION
Added

1. Telemetry functionality to log when this class gets used. Nothing beyond the signal that the class was used and the version of the class would be logged. Specifically, nothing what a user might be doing on the cluster itself. This functionality can be opted-out.
2. Fixed SSH functionality on Windows. 
3. Added time out functionality to shutdown the Dask cluster after 20 minutes of non-usage. Once we move to Kubernetes backed this will be reset to 5 minutes.
4. Updated docstring documentation.